### PR TITLE
Do not show extraneous true/false possible values, skip hidden arguments

### DIFF
--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -47,9 +47,6 @@ does testing things
 
 * `-l`, `--list` — lists test values
 
-  Possible values: `true`, `false`
-
-
 
 
 <hr/>

--- a/docs/examples/complex-app.md
+++ b/docs/examples/complex-app.md
@@ -6,6 +6,7 @@ This document contains the help content for the `complex-app` command-line progr
 
 * [`complex-app`↴](#complex-app)
 * [`complex-app test`↴](#complex-app-test)
+* [`complex-app only-hidden-options`↴](#complex-app-only-hidden-options)
 
 ## `complex-app`
 
@@ -16,6 +17,7 @@ An example command-line tool
 ###### **Subcommands:**
 
 * `test` — does testing things
+* `only-hidden-options` — Demo that `Options` is not printed if all options are hidden
 
 ###### **Arguments:**
 
@@ -46,6 +48,14 @@ does testing things
 ###### **Options:**
 
 * `-l`, `--list` — lists test values
+
+
+
+## `complex-app only-hidden-options`
+
+Demo that `Options` is not printed if all options are hidden
+
+**Usage:** `complex-app only-hidden-options`
 
 
 

--- a/docs/examples/complex_app.rs
+++ b/docs/examples/complex_app.rs
@@ -20,6 +20,9 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     debug: u8,
 
+    #[arg(short, long, hide = true)]
+    secret_arg: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -31,6 +34,11 @@ enum Commands {
         /// lists test values
         #[arg(short, long)]
         list: bool,
+    },
+    /// Demo that `Options` is not printed if all options are hidden
+    OnlyHiddenOptions {
+        #[arg(short, long, hide = true)]
+        secret: bool,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ fn write_help_markdown(
     // build_table_of_contents_html(buffer, Vec::new(), command, 0).unwrap();
     // writeln!(buffer, "</ul></div>").unwrap();
 
-    if ! options.disable_toc {
+    if !options.disable_toc {
         writeln!(buffer, "**Command Overview:**\n").unwrap();
 
         build_table_of_contents_markdown(buffer, Vec::new(), command, 0)
@@ -261,11 +261,7 @@ fn build_command_markdown(
     }
     */
 
-    writeln!(
-        buffer,
-        "## `{}`\n",
-        command_path.join(" "),
-    )?;
+    writeln!(buffer, "## `{}`\n", command_path.join(" "),)?;
 
     if let Some(long_about) = command.get_long_about() {
         writeln!(buffer, "{}\n", long_about)?;
@@ -316,15 +312,12 @@ fn build_command_markdown(
 
             let title_name = get_canonical_name(subcommand);
 
-            writeln!(
-                buffer,
-                "* `{}` — {}",
-                title_name,
-                match subcommand.get_about() {
-                    Some(about) => about.to_string(),
-                    None => String::new(),
-                }
-            )?;
+            writeln!(buffer, "* `{}` — {}", title_name, match subcommand
+                .get_about()
+            {
+                Some(about) => about.to_string(),
+                None => String::new(),
+            })?;
         }
 
         writeln!(buffer)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ fn build_command_markdown(
 
     let non_pos: Vec<_> = command
         .get_arguments()
-        .filter(|arg| !arg.is_positional())
+        .filter(|arg| !arg.is_positional() && !arg.is_hide_set())
         .collect();
 
     if !non_pos.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,11 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
         .filter(|pv| !pv.is_hide_set())
         .collect();
 
-    if !possible_values.is_empty() {
+    // Print possible values for options that take a value, but not for flags
+    // that can only be either present or absent and do not take a value.
+    if !possible_values.is_empty()
+        && !matches!(arg.get_action(), clap::ArgAction::SetTrue)
+    {
         let any_have_help: bool =
             possible_values.iter().any(|pv| pv.get_help().is_some());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,9 +377,6 @@ fn build_command_markdown(
 }
 
 fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
-    // Markdown list item
-    write!(buffer, "* ")?;
-
     let value_name: String = match arg.get_value_names() {
         // TODO: What if multiple names are provided?
         Some([name, ..]) => name.as_str().to_owned(),
@@ -389,6 +386,8 @@ fn write_arg_markdown(buffer: &mut String, arg: &clap::Arg) -> fmt::Result {
         None => arg.get_id().to_string().to_ascii_uppercase(),
     };
 
+    // Markdown list item
+    write!(buffer, "* ")?;
     match (arg.get_short(), arg.get_long()) {
         (Some(short), Some(long)) => {
             if arg.get_action().takes_values() {


### PR DESCRIPTION
Thank you for forking clap-markdown and making a release!

In case you are willing to publish more versions, here are two more bugfixes for clap-markdown (https://github.com/ConnorGray/clap-markdown/issues/18 and https://github.com/ConnorGray/clap-markdown/issues/19). See commit descriptions for more details.